### PR TITLE
Add an option to skip ssl certificate generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ nextcloud_version: 12.0.2 # version to install
 nextcloud_use_https: true # set to false if you want to run your instance behind a loadbalancer with ssl-termination
 nextcloud_ssl_cert: /etc/nginx/nextcloud.crt # self-signed ssl cert path
 nextcloud_ssl_key: /etc/nginx/nextcloud.key # ssl key path
+nextcloud_ssl_skip_gen: false # set to true if you do NOT want role to handle ssl cert generation (then you must provide nextcloud_ssl_* configured files)
 nextcloud_ssl_subject: '/C=CH/ST=Lucerne/L=Lucerne/O=/CN={{ nextcloud_domain }}' # subject for ssl cert
 nextcloud_working_dir: /nextcloud # directory for storing scripts
 nextcloud_web_root: /var/www/nextcloud # web root 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ nextcloud_domain: nextcloud.mydomain.com
 nextcloud_trusted_domains: ['localhost', '{{ nextcloud_domain }}']
 nextcloud_ssl_cert: /etc/nginx/nextcloud.crt
 nextcloud_ssl_key: /etc/nginx/nextcloud.key
+nextcloud_ssl_skip_gen: false
 nextcloud_ssl_subject: '/C=CH/ST=Lucerne/L=Lucerne/O=/CN={{ nextcloud_domain }}'
 nextcloud_web_root: /var/www/nextcloud
 nextcloud_data_root: /nextcloud/data

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,7 +170,7 @@
   command: 'openssl req -new -nodes -x509 -subj {{ nextcloud_ssl_subject }} -days 3650 -keyout {{ nextcloud_ssl_key }} -out {{nextcloud_ssl_cert }} -extensions v3_ca creates={{ nextcloud_ssl_cert }}'
   notify: 
     - reload nginx
-  when: nextcloud_use_https
+  when: nextcloud_use_https and not nextcloud_ssl_skip_gen
 
 - name: ensure php-fpm www.conf settings are correct
   lineinfile:


### PR DESCRIPTION
Previously, the only choices about ssl is to activate ssl with a
generated ssl certificate or not to use ssl.

A new configuration nextcloud_ssl_skip_gen allow to skip ssl certificate
generation. In this case, role caller must provide nextcloud_ssl_*
files.

nextcloud_ssl_skip_gen by default to false, to that existing configurations
do not break.

(And thanks for you work on this role)