### PR TITLE
workaround setup selinux https://github.com/ansible/ansible/issues/16612

### DIFF
--- a/tasks/permissions.yml
+++ b/tasks/permissions.yml
@@ -29,7 +29,7 @@
     - '{{ nextcloud_web_root }}/.htaccess'
     - '{{ nextcloud_web_root }}/.user.ini'
   register: sefcontext
-  when: ansible_selinux.status == 'enabled'
+  when: ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: run restorecon if SELinux file context was changed
   command: '{{ item  }}'
@@ -38,7 +38,7 @@
     - 'restorecon -Rv {{ nextcloud_upload_tmp_dir }}'
     - 'restorecon -Rv {{ nextcloud_web_root }}'
   when: 
-    - ansible_selinux.status == 'enabled'
+    - ansible_selinux and ansible_selinux.status == 'enabled'
     - sefcontext.changed
 
 - name: ensure sebooleans are set
@@ -50,4 +50,4 @@
     - 'httpd_can_network_connect'
     - 'httpd_execmem'
     - 'daemons_enable_cluster_mode'
-  when: ansible_selinux.status == 'enabled'
+  when: ansible_selinux and ansible_selinux.status == 'enabled'


### PR DESCRIPTION
``ansible_selinux`` is not always consistent; it may be either a dict with a
``status`` entry, or a boolean set to false.

This is fixed in ansible 2.4.1 (see link).

This commit enforces a first check on ansible_selinux before checking
ansible_selinux.enabled. It enables role to work with pre and post
ansible 2.4.1 as python non-empty dict is true for boolean checking.