### PR TITLE
Fix missing cron script

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -240,7 +240,7 @@
     name: nextcloud           
     minute: 15                
     user: nginx               
-    job: 'php -f /var/www/nextcloud/cron.php'
+    job: 'php -f {{ nextcloud_web_root | quote }}/cron.php'
 
 - import_tasks: 'permissions.yml'
 


### PR DESCRIPTION
Role erroneously uses a constant path for cron script, instead of ``nextcloud_web_root`` role variable.