### PR TITLE
support changing the http/https ports, for use behind a reverse proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ nextcloud_max_upload_size: 16G
 nextcloud_max_upload_time: 3600
 nextcloud_upload_tmp_dir: /nextcloud/tmp
 nextcloud_upgrade: false
+nextcloud_http_port: 80
+nextcloud_https_port: 443

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -198,6 +198,16 @@
     - { name: opcache.revalidate_freq, value: 1 }
   notify: restart php-fpm
 
+- name: ensure nginx is allowed to listen on nextcloud ports
+  seport:
+    ports: "{{ item }} "
+    proto: tcp
+    setype: http_port_t
+    state: present
+  with_items:
+    - "{{ nextcloud_http_port }}"
+    - "{{ nextcloud_https_port }}"
+
 - name: ensure nginx, php-fpm and redis are enabled and running
   service:
     name: '{{ item }}'

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -4,7 +4,7 @@ upstream php-handler {
 }
 
 server {
-    listen 80 default_server;
+    listen {{ nextcloud_http_port }} default_server;
     server_name {{ nextcloud_domain }};
 {% if nextcloud_use_https %}
     # enforce https
@@ -12,7 +12,7 @@ server {
 }
 
 server {
-    listen 443 ssl http2 default_server;
+    listen {{ nextcloud_https_port }} ssl http2 default_server;
     server_name {{ nextcloud_domain }};
 
     ssl_certificate {{ nextcloud_ssl_cert }};


### PR DESCRIPTION
This'll let you change the http and https ports for nextcloud's nginx config so you can run other services which bind to 80/443 on the same box (outside of nginx). 