### PR TITLE
Reorder perms and conf checks when upgrading

### DIFF
--- a/tasks/filesystem.yml
+++ b/tasks/filesystem.yml
@@ -1,0 +1,13 @@
+---
+# perform fixes on filesystem (selinux, perms,
+# configuration inside nextcloud_web_root)
+
+- name: ensure .user.ini config is present
+  template:
+    src: user.ini.j2
+    dest: '{{ nextcloud_web_root }}/.user.ini'
+  notify:
+    - reload nginx
+    - reload php-fpm
+
+- import_tasks: 'permissions.yml'

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -10,7 +10,7 @@
     remote_src: true
     dest: '{{ nextcloud_web_root }}'
 
-- import_tasks: 'permissions.yml'
+- import_tasks: 'filesystem.yml'
 
 - name: installation - ensure nextcloud installation is finished
   command: 'php {{ nextcloud_web_root }}/occ maintenance:install --database "mysql" --database-name "{{ nextcloud_mysql_db }}"  --database-user "{{ nextcloud_mysql_user }}" --database-pass "{{ nextcloud_mysql_pw }}" --admin-user "{{ nextcloud_admin_user }}" --admin-pass "{{ nextcloud_admin_pw }}" --data-dir "{{ nextcloud_data_root }}"'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -238,22 +238,16 @@
 - import_tasks: 'installation.yml'
   when: new_installation.changed
 
-- name: ensure .user.ini config is present
-  template:
-    src: user.ini.j2
-    dest: '{{ nextcloud_web_root }}/.user.ini'
-  notify:
-    - reload nginx
-    - reload php-fpm
-
-- name: performance tuning - ensure the nextcloud cronjob exists and runs every 15 min         
-  cron:               
-    name: nextcloud           
-    minute: 15                
-    user: nginx               
-    job: 'php -f {{ nextcloud_web_root | quote }}/cron.php'
-
-- import_tasks: 'permissions.yml'
-
 - import_tasks: 'upgrade.yml'
   when: nextcloud_upgrade
+
+# call filesystem checks if not done by previous tasks
+- import_tasks: filesystem.yml
+  when: not new_installation.changed and not new_installation.changed
+
+- name: performance tuning - ensure the nextcloud cronjob exists and runs every 15 min
+  cron:
+    name: nextcloud
+    minute: 15
+    user: nginx
+    job: 'php -f {{ nextcloud_web_root | quote }}/cron.php'

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -15,6 +15,8 @@
   register: nextcloud_update_result
   changed_when: false # unsure if upgrade has been done -> inform later
 
+- import_tasks: filesystem.yml
+
 - name: get current nextcloud version, after running updater.phar
   shell: '{{ nextcloud_web_root }}/occ -V'
   become: true


### PR DESCRIPTION
Previously, upgrade behavior ended inconsistently as upgrade process
replaced nextcloud_web_root files with the ones from the update archive after task that checked .user.ini file (so .user.ini file and some custom permissions were erased).

A second run was necessary to install desired .user.ini file.

This PR puts .user.ini and permission tasks in a filesystem.yml file that is included at the right place for all scenarios (install, upgrade, check).