### PR TITLE
Make it simple to not modify the mysql root password

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Role Variables
 
 ```
 nextcloud_domain: nextcloud.mydomain.com # domain used in nginx and nextcloud version (REQUIRED)
-mysql_root_pw: secret # root password for 
+mysql_root_pw_modify: true # set to false if you do NOT want to modify the mysql root password
+mysql_root_pw: secret # root password for mysql
 nextcloud_repo_url: https://download.nextcloud.com/server/releases # where to get the nextcloud archive
 nextcloud_version: nextcloud-14.0.3 # version to install, choose any from https://download.nextcloud.com/server/releases/ without the file extion (default: latest)
 nextcloud_use_https: true # set to false if you want to run your instance behind a loadbalancer with ssl-termination

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for rbicker.nextcloud
 
+mysql_root_pw_modify: true
 mysql_root_pw: secret
 nextcloud_repo_url: https://download.nextcloud.com/server/releases
 nextcloud_version: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,7 +177,7 @@
     group: nginx
     state: directory
 
-- name: enusre /etc/nginx/nginx.conf is present
+- name: ensure /etc/nginx/nginx.conf is present
   copy:
     src: nginx.conf
     dest: /etc/nginx/nginx.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,6 +79,7 @@
     login_user: root
     name: root
     password: '{{ mysql_root_pw }}'
+  when: mysql_root_pw_modify
 
 - name: ensure /root/.my.cnf is present
   template:
@@ -88,6 +89,7 @@
     group: root
     mode: '0600'
     force: no # don't overwrite, only create if not exists
+  when: mysql_root_pw_modify
 
 - name: ensure anonymous mysql user is absent
   mysql_user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,6 @@
       - php71w-fpm
       - php71w-opcache
       - php71w-common # ctype, iconv, json, libxml, simplexml, zip, zlib, curl, fileinfo, bz2, openssl, ftp, exif, gmp
-      - php71w-xml
       - php71w-gd
       - php71w-xml # dom, xmlreader, xmlwriter
       - php71w-mbstring


### PR DESCRIPTION
Thank you for this ansible role. Here are a couple of modifications I made when I used it, most notably introducing a `mysql_root_pw_modify` variable to make it possible to install without specifying and modifying the mysql root password.