### PR TITLE
fix --check use

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
     ls /etc/yum.repos.d/remi-php* | grep -v remi-php{{ php_version | replace(".","") }}
   register: php_repos
   when: nextcloud_manage_yum_repos and ansible_distribution_major_version|int <= 7
+  check_mode: false
   changed_when: no
 
 - name: ensure correct PHP repo is enabled and has the correct priority


### PR DESCRIPTION
A missing ``check_mode: false`` prevents nextcloud role to be run in check_mode.

This pull request fixes this.