### PR TITLE
ensure directories that used for nextcloud exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -273,7 +273,7 @@
 
 - name: ensure directory for php sessions and caches exist
   file:
-    path: /var/lib/php/session
+    path: '{{ item }}' 
     owner: nginx
     group: nginx
     state: directory


### PR DESCRIPTION
The directory list in loop doesn't created since hardcoded to `/var/lib/php/session`